### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+***IMPORTANT: This project has been archived and is part of the official [cue-lang](https://github.com/cue-lang/) org! Please use the official [action](https://github.com/cue-lang/setup-cue) and not this one!***
+
 # Setup CUE
 
 ***Install a specific [CUE](https://github.com/cue-lang/cue) cli version on your Github Actions runner***


### PR DESCRIPTION
Adds a hint for people to use the [official](https://github.com/cue-lang/setup-cue) version. 
Already de-listed the action from the marketplace. When this PR is merged we can archive this repo (and maybe delete it in half a year or so)